### PR TITLE
added support for integer conversion from DefaultHeaderStrategyOptional

### DIFF
--- a/Sources/Postie/Decoder/ResponseDecoding.swift
+++ b/Sources/Postie/Decoder/ResponseDecoding.swift
@@ -43,10 +43,8 @@ internal struct ResponseDecoding: Decoder {
 
             if let value = value as? String, existingKey == header.lowercased() {
                 switch T.self {
-                case is String.Type:
-                    return value as? T
-
-                case is Int.Type:
+                case is IntegerLiteralType.Type,
+                     is IntegerLiteralType?.Type:
                     return Int(value) as? T
 
                 default:

--- a/Sources/Postie/Strategies/Headers/DefaultHeaderStrategyOptional.swift
+++ b/Sources/Postie/Strategies/Headers/DefaultHeaderStrategyOptional.swift
@@ -1,10 +1,8 @@
 import Foundation
 
-public struct DefaultHeaderStrategyOptional: ResponseHeaderDecodingStrategy {
+public struct DefaultHeaderStrategyOptional<RawValue>: ResponseHeaderDecodingStrategy where RawValue: Codable {
 
-    public typealias RawValue = String?
-
-    public static func decode(decoder: Decoder) throws -> RawValue {
+    public static func decode(decoder: Decoder) throws -> RawValue? {
         guard let key = decoder.codingPath.last?.stringValue else {
             throw ResponseHeaderDecodingError.missingCodingKey
         }
@@ -13,6 +11,9 @@ public struct DefaultHeaderStrategyOptional: ResponseHeaderDecodingStrategy {
             return try RawValue(from: decoder)
         }
         // Transform dash separator to camelCase
-        return responseDecoding.valueForHeaderCaseInsensitive(key)
+        guard let value: RawValue? = responseDecoding.valueForHeaderCaseInsensitive(key) else {
+            return nil
+        }
+        return value
     }
 }

--- a/Tests/PostieTests/ResponseHeaderCodingTests.swift
+++ b/Tests/PostieTests/ResponseHeaderCodingTests.swift
@@ -13,7 +13,10 @@ private struct Response: Decodable {
     var contentType: String
 
     @ResponseHeader<DefaultHeaderStrategyOptional>
-    var optionalValue: String?
+    var optionalStringValue: String?
+
+    @ResponseHeader<DefaultHeaderStrategyOptional>
+    var optionalIntValue: Int?
 }
 
 class ResponseHeaderCodingTests: XCTestCase {
@@ -22,7 +25,7 @@ class ResponseHeaderCodingTests: XCTestCase {
         "authorization": "Bearer Token",
         "LENGTH": "123",
         "Content-Type": "application/json",
-        "X-CUSTOM-HEADER": "second custom header"
+        "X-CUSTOM-HEADER": "second custom header",
     ])!
 
     func testDecoding_defaultStrategy_shouldDecodeCaseInSensitiveResponseHeaders() {
@@ -42,26 +45,49 @@ class ResponseHeaderCodingTests: XCTestCase {
         XCTAssertEqual(decoded.contentType, "application/json")
     }
 
-    func testDecoding_optionalValueNotGiven_shouldDecodeToNil() {
+    func testDecoding_optionalStringValueNotGiven_shouldDecodeToNil() {
         let decoder = ResponseDecoder()
         guard let decoded = CheckNoThrow(try decoder.decode(Response.self, from: (Data(), response))) else {
             return
         }
-        XCTAssertNil(decoded.optionalValue)
+        XCTAssertNil(decoded.optionalStringValue)
     }
 
-    func testDecoding_optionalValueGiven_shouldDecodeToValue() {
+    func testDecoding_optionalIntValueNotGiven_shouldDecodeToNil() {
+        let decoder = ResponseDecoder()
+        guard let decoded = CheckNoThrow(try decoder.decode(Response.self, from: (Data(), response))) else {
+            return
+        }
+        XCTAssertNil(decoded.optionalIntValue)
+    }
+
+    func testDecoding_optionalStringValueGiven_shouldDecodeToValue() {
         let response = HTTPURLResponse(url: URL(string: "http://example.local")!, statusCode: 200, httpVersion: nil, headerFields: [
             "authorization": "Bearer Token",
             "LENGTH": "123",
             "Content-Type": "application/json",
             "X-Custom-Header": "a custom value",
-            "optionalValue": "value"
+            "optionalStringValue": "value",
         ])!
         let decoder = ResponseDecoder()
         guard let decoded = CheckNoThrow(try decoder.decode(Response.self, from: (Data(), response))) else {
             return
         }
-        XCTAssertEqual(decoded.optionalValue, "value")
+        XCTAssertEqual(decoded.optionalStringValue, "value")
+    }
+
+    func testDecoding_optionalIntValueGiven_shouldDecodeToValue() {
+        let response = HTTPURLResponse(url: URL(string: "http://example.local")!, statusCode: 200, httpVersion: nil, headerFields: [
+            "authorization": "Bearer Token",
+            "LENGTH": "123",
+            "Content-Type": "application/json",
+            "X-Custom-Header": "a custom value",
+            "optionalIntValue": "10",
+        ])!
+        let decoder = ResponseDecoder()
+        guard let decoded = CheckNoThrow(try decoder.decode(Response.self, from: (Data(), response))) else {
+            return
+        }
+        XCTAssertEqual(decoded.optionalIntValue, 10)
     }
 }


### PR DESCRIPTION
this relies on the same principle found in DefaultHeaderStrategy

added some test cases

Note: this feature might be helpful when retrieving page/page count/items count/… in header and converting them directly to a more compatible and useful type than a String.